### PR TITLE
Add evalConfig parameter to TypeScript SDK evaluator

### DIFF
--- a/typescript/ai-evaluation/package.json
+++ b/typescript/ai-evaluation/package.json
@@ -89,17 +89,16 @@
     "typescript": "^5.3.0"
   },
   "dependencies": {
+    "@future-agi/sdk": "^0.1.1",
+    "@traceai/fi-core": "^0.1.16",
     "axios": "^1.6.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "ora": "^8.0.0",
     "winston": "^3.11.0",
     "yaml": "^2.3.0",
-    "zod": "^3.22.0",
-    "@future-agi/sdk": ">=0.1.0",
-    "@traceai/fi-core": ">=0.1.15"
+    "zod": "^3.22.0"
   },
-  "peerDependencies": {},
   "publishConfig": {
     "access": "public"
   }

--- a/typescript/ai-evaluation/src/evaluator.ts
+++ b/typescript/ai-evaluation/src/evaluator.ts
@@ -158,7 +158,8 @@ export class Evaluator extends APIKeyAuth {
             traceEval: initialTraceEval = false,
             platform,
             isAsync = false,
-            errorLocalizer = false
+            errorLocalizer = false,
+            evalConfig
         } = options;
 
         // Handle platform configuration (e.g., Langfuse)
@@ -281,7 +282,7 @@ export class Evaluator extends APIKeyAuth {
             }
         }
 
-        const finalApiPayload = {
+        const finalApiPayload: Record<string, any> = {
             eval_name: evalName,
             inputs: transformedApiInputs,
             model: modelName,
@@ -291,6 +292,10 @@ export class Evaluator extends APIKeyAuth {
             is_async: isAsync,
             error_localizer: errorLocalizer,
         };
+
+        if (evalConfig) {
+            finalApiPayload.config = { params: evalConfig };
+        }
 
         // Convert timeout (seconds) to milliseconds for axios. Use a higher default (200s) if not provided.
         const timeoutMs = timeout !== undefined ? timeout * 1000 : this.defaultTimeout * 1000;

--- a/typescript/ai-evaluation/src/types.ts
+++ b/typescript/ai-evaluation/src/types.ts
@@ -323,6 +323,8 @@ interface EvaluateOptions {
   isAsync?: boolean;
   /** Enable error localization to identify specific failure points */
   errorLocalizer?: boolean;
+  /** Eval-specific configuration, e.g. { k: 3 } for retrieval metrics (recall_at_k, precision_at_k, ndcg_at_k) */
+  evalConfig?: Record<string, any>;
 }
 
 /**


### PR DESCRIPTION
## Summary                                                                                                                                                                                                           
  - Add `evalConfig` parameter to `EvaluateOptions` interface in TypeScript SDK                                                                                                                                      
  - Inject `config.params` into API payload when `evalConfig` is provided
  - Mirrors the Python SDK `eval_config` parameter added in v1.0.1

  ## Changes
  - `typescript/ai-evaluation/src/types.ts` — Added `evalConfig?: Record<string, any>` to `EvaluateOptions`
  - `typescript/ai-evaluation/src/evaluator.ts` — Destructure `evalConfig` from options, inject into payload as `config: { params: evalConfig }`
  - `typescript/ai-evaluation/package.json` — Dependency version pinning cleanup

  ## Usage
  ```typescript
  const result = await evaluator.evaluate("recall_at_k", inputs, {
    modelName: "turing_flash",
    evalConfig: { k: 3 },
  });

  Tested

  All 5 retrieval evals verified against production API (api.futureagi.com):
  - recall_at_k (k=3, k=500)
  - precision_at_k (k=3, k=500)
  - ndcg_at_k (k=3, k=500)
  - mrr
  - hit_rate
  - Batch (multi-row) recall_at_k with 3 rows