### PR TITLE
fix: update protect metric names with backward-compatible aliases (TH…

### DIFF
--- a/python/fi/evals/evaluator.py
+++ b/python/fi/evals/evaluator.py
@@ -236,7 +236,7 @@ class Evaluator(APIKeyAuth):
                             logging.warning("Failed to trace the evaluation. Custom eval configuration with the same name already exists for this project")
                     else:
                         trace_eval = False
-                        logging.debug(
+                        logging.warning(
                             "Could not determine project_name from OpenTelemetry context. "
                             "Skipping check for existing custom eval configuration."
                         )

--- a/python/fi/evals/evaluator.py
+++ b/python/fi/evals/evaluator.py
@@ -236,7 +236,7 @@ class Evaluator(APIKeyAuth):
                             logging.warning("Failed to trace the evaluation. Custom eval configuration with the same name already exists for this project")
                     else:
                         trace_eval = False
-                        logging.warning(
+                        logging.debug(
                             "Could not determine project_name from OpenTelemetry context. "
                             "Skipping check for existing custom eval configuration."
                         )

--- a/python/fi/evals/protect.py
+++ b/python/fi/evals/protect.py
@@ -1,6 +1,7 @@
 import re
 import copy
 import time
+import warnings
 from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
 from typing import Dict, List, Optional, Tuple, Any
 from urllib.parse import urlparse
@@ -53,10 +54,17 @@ class Protect:
 
         # Map metric names to their corresponding template classes
         self.metric_map = {
-            "content_moderation": Toxicity,
+            "toxicity": Toxicity,
             "bias_detection": BiasDetection,
-            "security": PromptInjection,
+            "prompt_injection": PromptInjection,
             "data_privacy_compliance": DataPrivacyCompliance,
+            # Deprecated aliases (still supported)
+            "content_moderation": Toxicity,
+            "security": PromptInjection,
+        }
+        self._deprecated_metrics = {
+            "content_moderation": "toxicity",
+            "security": "prompt_injection",
         }
 
     def _sanitize_reason(self, text: Optional[str]) -> Optional[str]:
@@ -523,12 +531,21 @@ class Protect:
             # Validate metric name first, as other validations might depend on it
             if rule["metric"] not in valid_metrics:
                 raise InvalidValueType(
-                    value_name=f"metric in Rule at index {i}", 
-                    value=rule["metric"], 
+                    value_name=f"metric in Rule at index {i}",
+                    value=rule["metric"],
                     correct_type=f"one of {list(valid_metrics)}"
                 )
 
-         
+            # Warn about deprecated metric names
+            if rule["metric"] in self._deprecated_metrics:
+                new_name = self._deprecated_metrics[rule["metric"]]
+                warnings.warn(
+                    f'Protect metric "{rule["metric"]}" is deprecated and will be '
+                    f'removed in a future release. Please use "{new_name}" instead.',
+                    FutureWarning,
+                    stacklevel=2,
+                )
+
             is_tone_metric = rule["metric"] == "Tone"
 
             if is_tone_metric:


### PR DESCRIPTION
## Description

Updates Protect metric names to match the underlying eval templates, with backward-compatible deprecated aliases (TH-3610).

### Changes
- **Primary metric names** are now `toxicity` and `prompt_injection` (matching the template class names)
- **Deprecated aliases** `content_moderation` (for `toxicity`) and `security` (for `prompt_injection`) still work but emit a `FutureWarning`
- `bias_detection` and `data_privacy_compliance` are unchanged

### Why
The old names (`content_moderation`, `security`) didn't match the actual eval template names (`Toxicity`, `PromptInjection`), causing confusion in the SDK and documentation.

## Files Changed
- `python/fi/evals/protect.py` - Updated `metric_map` with primary + deprecated entries, added `_deprecated_metrics` dict, added `FutureWarning` in rule validation loop

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)