### PR TITLE
feat: add A2A eval names (a2a_task_completion, a2a_response_alignment…

### DIFF
--- a/python/fi/evals/__init__.py
+++ b/python/fi/evals/__init__.py
@@ -121,6 +121,13 @@ streaming_names = [
     "StreamingState",
 ]
 
+# A2A exports
+a2a_names = [
+    "A2A_TASK_COMPLETION",
+    "A2A_RESPONSE_ALIGNMENT",
+    "A2A_SAFETY_PASS_THROUGH"
+]
+
 __all__ = sorted(
     new_api_names
     + execution_names
@@ -128,4 +135,5 @@ __all__ = sorted(
     + client_names
     + framework_names
     + streaming_names
+    + a2a_names
 )

--- a/python/fi/evals/templates.py
+++ b/python/fi/evals/templates.py
@@ -470,3 +470,37 @@ class CustomerAgentQueryHandling(EvalTemplate):
 
 class CustomerAgentTerminationHandling(EvalTemplate):
     eval_name = "customer_agent_termination_handling"
+
+
+# ---------------------------------------------------------------------------
+# Agent-to-Agent (A2A) Evaluations
+# ---------------------------------------------------------------------------
+
+class A2ATaskCompletion(EvalTemplate):
+    eval_name = "a2a_task_completion"
+    display_name = "A2A Task Completion"
+    description = "Checks if a remote A2A agent completed the delegated task correctly"
+    required_keys = ["output", "expected_output", "task_description"]
+    eval_tags = ["agent_trajectory"]
+
+
+class A2AResponseAlignment(EvalTemplate):
+    eval_name = "a2a_response_alignment"
+    display_name = "A2A Response Alignment"
+    description = "Checks if the A2A agent response is semantically aligned with the caller's request"
+    required_keys = ["input", "output", "context"]
+    eval_tags = ["rag", "relevancy"]
+
+
+class A2ASafetyPassThrough(EvalTemplate):
+    eval_name = "a2a_safety_pass_through"
+    display_name = "A2A Safety Pass-Through"
+    description = "Checks no unsafe content was introduced or passed through during an A2A agent exchange"
+    required_keys = ["input", "output"]
+    eval_tags = ["safety"]
+
+
+# --- Agent-to-Agent (A2A) Evaluations ---
+A2A_TASK_COMPLETION    = "a2a_task_completion"
+A2A_RESPONSE_ALIGNMENT = "a2a_response_alignment"
+A2A_SAFETY_PASS_THROUGH = "a2a_safety_pass_through"

--- a/python/tests/sdk/test_evaluator.py
+++ b/python/tests/sdk/test_evaluator.py
@@ -141,6 +141,46 @@ class TestEvaluate:
 
         assert result is not None
 
+    @patch.object(Evaluator, 'request')
+    def test_evaluate_a2a_task_completion(self, mock_request, evaluator):
+        """Test evaluate with A2ATaskCompletion."""
+        mock_request.return_value = BatchRunResult(eval_results=[
+            EvalResult(name="a2a_task_completion", output=1.0)
+        ])
+        result = evaluator.evaluate(
+            eval_templates="a2a_task_completion",
+            inputs={"output": "success", "expected_output": "success", "task_description": "test"},
+            model_name="turing_flash"
+        )
+        assert result is not None
+        assert result.eval_results[0].name == "a2a_task_completion"
+
+    @patch.object(Evaluator, 'request')
+    def test_evaluate_a2a_response_alignment(self, mock_request, evaluator):
+        """Test evaluate with A2AResponseAlignment."""
+        mock_request.return_value = BatchRunResult(eval_results=[
+            EvalResult(name="a2a_response_alignment", output=0.9)
+        ])
+        result = evaluator.evaluate(
+            eval_templates="a2a_response_alignment",
+            inputs={"input": "test request", "output": "test response", "context": "test context"},
+            model_name="turing_flash"
+        )
+        assert result is not None
+
+    @patch.object(Evaluator, 'request')
+    def test_evaluate_a2a_safety_pass_through(self, mock_request, evaluator):
+        """Test evaluate with A2ASafetyPassThrough."""
+        mock_request.return_value = BatchRunResult(eval_results=[
+            EvalResult(name="a2a_safety_pass_through", output="SAFE")
+        ])
+        result = evaluator.evaluate(
+            eval_templates="a2a_safety_pass_through",
+            inputs={"input": "test input", "output": "test output"},
+            model_name="turing_flash"
+        )
+        assert result is not None
+
     def test_evaluate_invalid_template_type(self, evaluator):
         """Test evaluate with invalid template type."""
         with pytest.raises(TypeError):

--- a/python/tests/sdk/test_templates.py
+++ b/python/tests/sdk/test_templates.py
@@ -55,6 +55,12 @@ from fi.evals.templates import (
     TaskCompletion,
     CaptionHallucination,
     BleuScore,
+    A2ATaskCompletion,
+    A2AResponseAlignment,
+    A2ASafetyPassThrough,
+    A2A_TASK_COMPLETION,
+    A2A_RESPONSE_ALIGNMENT,
+    A2A_SAFETY_PASS_THROUGH,
 )
 
 
@@ -443,6 +449,41 @@ class TestOtherTemplates:
         template = BleuScore()
         assert template.eval_name == "bleu_score"
         assert template.eval_id == "101"
+
+
+class TestA2ATemplates:
+    """Tests for A2A-related templates and constants."""
+
+    def test_a2a_task_completion(self):
+        """Test A2ATaskCompletion template."""
+        template = A2ATaskCompletion()
+        assert template.eval_name == "a2a_task_completion"
+        assert A2A_TASK_COMPLETION == "a2a_task_completion"
+
+    def test_a2a_response_alignment(self):
+        """Test A2AResponseAlignment template."""
+        template = A2AResponseAlignment()
+        assert template.eval_name == "a2a_response_alignment"
+        assert A2A_RESPONSE_ALIGNMENT == "a2a_response_alignment"
+
+    def test_a2a_safety_pass_through(self):
+        """Test A2ASafetyPassThrough template."""
+        template = A2ASafetyPassThrough()
+        assert template.eval_name == "a2a_safety_pass_through"
+        assert A2A_SAFETY_PASS_THROUGH == "a2a_safety_pass_through"
+
+    def test_a2a_public_api_exports(self):
+        """Test that A2A names are accessible via public API."""
+        import fi.evals as evals
+        assert "A2A_TASK_COMPLETION" in dir(evals)
+        assert evals.A2A_TASK_COMPLETION == "a2a_task_completion"
+        assert "A2A_RESPONSE_ALIGNMENT" in dir(evals)
+        assert evals.A2A_RESPONSE_ALIGNMENT == "a2a_response_alignment"
+        assert "A2A_SAFETY_PASS_THROUGH" in dir(evals)
+        assert evals.A2A_SAFETY_PASS_THROUGH == "a2a_safety_pass_through"
+        assert "A2ATaskCompletion" in dir(evals)
+        assert "A2AResponseAlignment" in dir(evals)
+        assert "A2ASafetyPassThrough" in dir(evals)
 
 
 class TestTemplateWithConfig:


### PR DESCRIPTION
## What does this PR do?

Adds three new Agent-to-Agent (A2A) evaluation names to the framework, 
as requested by @NVJKKartik in traceAI PR #153.

These eval names were originally added to the traceAI instrumentation repo 
but the maintainer correctly pointed out they belong here in ai-evaluation 
as they are FutureAGI system-level evaluation definitions.

## Changes

**`python/fi/evals/__init__.py`**
- Added `a2a_names` export list with all 3 A2A constants
- Registered `a2a_names` in `__all__` alongside existing name groups
  (new_api_names, execution_names, evaluation_template_names, 
  client_names, framework_names, streaming_names)

**`python/fi/evals/templates.py`**
- Added `A2ATaskCompletion` EvalTemplate
  - eval_name: `a2a_task_completion`
  - required_keys: output, expected_output, task_description
  - eval_tags: agent_trajectory
- Added `A2AResponseAlignment` EvalTemplate
  - eval_name: `a2a_response_alignment`
  - required_keys: input, output, context
  - eval_tags: rag, relevancy
- Added `A2ASafetyPassThrough` EvalTemplate
  - eval_name: `a2a_safety_pass_through`
  - required_keys: input, output
  - eval_tags: safety
- Added 3 module-level constants:
  `A2A_TASK_COMPLETION`, `A2A_RESPONSE_ALIGNMENT`, `A2A_SAFETY_PASS_THROUGH`

**`python/tests/sdk/test_evaluator.py`**
- Added `test_evaluate_a2a_task_completion`
- Added `test_evaluate_a2a_response_alignment`
- Added `test_evaluate_a2a_safety_pass_through`

**`python/tests/sdk/test_templates.py`**
- Added `TestA2ATemplates` class covering:
  - `test_a2a_task_completion`
  - `test_a2a_response_alignment`
  - `test_a2a_safety_pass_through`
  - `test_a2a_public_api_exports` — verifies all 3 names and 
    template classes are accessible via `import fi.evals`

## Why?

These evals enable quality scoring for Agent-to-Agent protocol workflows:
- `a2a_task_completion` — did the remote agent complete the delegated task correctly?
- `a2a_response_alignment` — is the agent's response semantically aligned with the caller's request?
- `a2a_safety_pass_through` — was any unsafe content introduced during an A2A agent exchange?

## How was it tested?

- [x] Unit tests added in `test_evaluator.py` and `test_templates.py`
- [x] Integration tests — N/A (no gateway behavior changed)
- [x] No TODOs or commented-out code left in
- [x] No real API keys or secrets in the diff

## Checklist

- [x] Branch is off `main`
- [x] Commit messages follow Conventional Commits (`feat:`)
- [x] No TODOs or commented-out code left in
- [x] No real API keys or secrets in the diff

## Related

- Requested by @NVJKKartik in: https://github.com/future-agi/traceAI/pull/153#discussion_r3116322852
- Original traceAI PR: https://github.com/future-agi/traceAI/pull/153