### PR TITLE
fix(ci): unbreak release pipeline (OTEL types + npm OIDC publish)

### DIFF
--- a/typescript/ai-evaluation/package.json
+++ b/typescript/ai-evaluation/package.json
@@ -86,7 +86,16 @@
     "ts-jest": "^29.1.0",
     "tsc-alias": "^1.8.0",
     "tsx": "^4.0.0",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "@opentelemetry/api": "^1.9.0"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.9.0"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@traceai/fi-core": "^0.1.16",

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
         specifier: ^3.22.0
         version: 3.25.76
     devDependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@types/jest':
         specifier: ^29.5.0
         version: 29.5.14


### PR DESCRIPTION
## Summary
Two CI fixes blocking the release pipeline:

**1. TS build (\`@opentelemetry/api\` not resolving)**
\`src/evaluator.ts\` does \`await import('@opentelemetry/api')\` at lines 245 and 495, but the package wasn't declared in \`package.json\` — only present transitively via \`@traceai/fi-core\`, which pnpm doesn't hoist. CI \`tsc\` failed with TS2307. Added it as a devDependency (build-time types) + optional peerDependency (runtime import is wrapped in try/catch with a graceful fallback warning).

**2. npm publish 404 (OIDC trusted publishing)**
The release job signed provenance fine, then got \`404 Not Found\` on the registry PUT. Cause: \`pnpm publish\` doesn't speak npm's OIDC → registry token-exchange protocol. It signs provenance via OIDC but doesn't authenticate to the registry, so npm rejects with its misleading 404-means-unauthorized error. Fix: bump npm to >= 11.5.1 and use \`npm publish\` (only the npm CLI implements trusted publishing).

## Test plan
- [x] \`pnpm run build\` passes locally
- [ ] CI build job green
- [ ] Next merge to main publishes to npm cleanly