### PR TITLE
fix(ci): publish via npm CLI to use OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,10 +222,14 @@ jobs:
         working-directory: typescript/ai-evaluation
         run: pnpm build
 
+      - name: Ensure npm >= 11.5.1 (OIDC trusted publishing)
+        if: steps.compare.outputs.should_publish == 'yes'
+        run: npm install -g npm@latest
+
       - name: Publish to npm (trusted publishing via OIDC + provenance)
         if: steps.compare.outputs.should_publish == 'yes'
         working-directory: typescript/ai-evaluation
-        run: pnpm publish --access public --provenance --no-git-checks
+        run: npm publish --access public --provenance
 
       - name: Tag release
         if: steps.compare.outputs.should_publish == 'yes'


### PR DESCRIPTION
## Summary
Last release run signed provenance fine, then 404'd on the registry PUT:
\`\`\`
npm notice publish Signed provenance statement ...
npm error 404 Not Found - PUT https://registry.npmjs.org/@future-agi%2fai-evaluation
\`\`\`

Cause: \`pnpm publish\` doesn't implement npm's OIDC → registry token-exchange protocol. It signs provenance via OIDC but doesn't authenticate to the registry, so npm rejects with its misleading 404-means-unauthorized error.

Fix: bump npm to >= 11.5.1 and use \`npm publish\` (only the npm CLI implements trusted publishing). Build still uses pnpm.

## Test plan
- [ ] CI green on this PR (no publish step runs — guarded by version bump)
- [ ] Next merge to main publishes to npm cleanly via OIDC