### PR TITLE
fix(ci): correct repository URL to match GitHub org slug

### DIFF
--- a/typescript/ai-evaluation/package.json
+++ b/typescript/ai-evaluation/package.json
@@ -61,12 +61,12 @@
   "author": "Future AGI <no-reply@futureagi.com>",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/futureagi/ai-evaluation.git"
+    "url": "git+https://github.com/future-agi/ai-evaluation.git"
   },
   "bugs": {
-    "url": "https://github.com/futureagi/ai-evaluation/issues"
+    "url": "https://github.com/future-agi/ai-evaluation/issues"
   },
-  "homepage": "https://github.com/futureagi/ai-evaluation#readme",
+  "homepage": "https://github.com/future-agi/ai-evaluation#readme",
   "engines": {
     "node": ">=18.0.0",
     "pnpm": ">=8.0.0"


### PR DESCRIPTION
## Summary
- Fixes npm publish E422 caused by provenance bundle validation
- `package.json` `repository.url` had `futureagi/ai-evaluation` (no hyphen), but the actual GitHub org is `future-agi`
- Provenance validator does a literal compare between the URL in the published tarball and the repo computed from the GitHub Actions workflow context, so they have to match exactly

## Why this surfaced now
Prior PRs on this branch enabled OIDC trusted publishing. Provenance only validates `repository.url` once trusted publishing is on, so the long-standing typo was silent until now.

## Test plan
- [ ] Re-run the publish workflow after merge — provenance bundle validation should succeed
- [ ] Confirm package appears on npm with provenance attestation