### PR TITLE
docs: correct contributor license to Apache 2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,4 +35,4 @@ Open a [Discussion](https://github.com/future-agi/ai-evaluation/discussions) or 
 
 ---
 
-By contributing, you agree that your contributions will be licensed under GPL-3.0.
+By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
## What does this PR do?

Corrects the contributor license statement in `CONTRIBUTING.md` from `GPL-3.0` to `Apache License 2.0`, aligning it with the project's actual license.

## Why?

The current text on the last line of `CONTRIBUTING.md` says:

> By contributing, you agree that your contributions will be licensed under GPL-3.0.

However, every other source of truth in the repo declares the project as Apache 2.0:

- [`LICENSE`](../LICENSE) — full Apache License 2.0 text
- [`NOTICE`](../NOTICE) — "licensed under the Apache License, Version 2.0"
- [`README.md`](../README.md) — Apache 2.0 license badge
- GitHub repo metadata (`license.spdx_id == "Apache-2.0"`)

This is almost certainly a leftover from a template, and it's the kind of inconsistency that can give prospective contributors pause about which terms actually apply. Fixing the line so it matches the rest of the project.

## How was it tested?

Documentation-only change; no code paths touched.

- [x] Unit tests added / updated — N/A (docs-only)
- [x] Integration tests pass — N/A (no gateway behavior changed)
- [x] `ruff check` / `mypy` / `npm run typecheck` / `npm run lint` all pass — N/A (docs-only)
- [x] Public types, env vars, or SDK behavior changes are documented in the relevant README — N/A

## Checklist

- [x] Branch is off `main`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`docs:`)
- [x] No TODOs or commented-out code left in
- [x] No real API keys or secrets in the diff
- [x] If prose was added or changed: checked against [`docs/VOCABULARY.md`](../docs/VOCABULARY.md)

## Notes for reviewers

If `GPL-3.0` was actually intended (e.g. dual-licensing plan), this PR is wrong and should be closed — happy to instead update `LICENSE`, `NOTICE`, and the README badge to match. Just let me know which direction is correct.
