### PR TITLE
feat: add PHONETIC comparator to Python and TypeScript SDK types and …

### DIFF
--- a/python/fi/evals/types.py
+++ b/python/fi/evals/types.py
@@ -154,3 +154,4 @@ class Comparator(Enum):
     JARO_WINKLER = "JaroWincklerSimilarity"
     JACCARD = "JaccardSimilarity"
     SORENSEN_DICE = "SorensenDiceSimilarity"
+    PHONETIC = "PhoneticSimilarity"

--- a/python/tests/sdk/test_types.py
+++ b/python/tests/sdk/test_types.py
@@ -101,10 +101,12 @@ class TestComparator:
         assert Comparator.JARO_WINKLER.value == "JaroWincklerSimilarity"
         assert Comparator.JACCARD.value == "JaccardSimilarity"
         assert Comparator.SORENSEN_DICE.value == "SorensenDiceSimilarity"
+        assert Comparator.PHONETIC.value == "PhoneticSimilarity"
+
 
     def test_comparator_count(self):
-        """Test that we have exactly 5 comparators."""
-        assert len(Comparator) == 5
+        """Test that we have exactly 6 comparators."""
+        assert len(Comparator) == 6
 
 
 class TestEvalResult:

--- a/typescript/ai-evaluation/src/__tests__/types.test.ts
+++ b/typescript/ai-evaluation/src/__tests__/types.test.ts
@@ -75,11 +75,12 @@ describe('Types', () => {
             expect(Comparator.JARO_WINKLER).toBe('JaroWincklerSimilarity');
             expect(Comparator.JACCARD).toBe('JaccardSimilarity');
             expect(Comparator.SORENSEN_DICE).toBe('SorensenDiceSimilarity');
+            expect(Comparator.PHONETIC).toBe('PhoneticSimilarity');
         });
 
-        it('should have exactly 5 comparators', () => {
+        it('should have exactly 6 comparators', () => {
             const comparatorValues = Object.values(Comparator);
-            expect(comparatorValues.length).toBe(5);
+            expect(comparatorValues.length).toBe(6);
         });
     });
 

--- a/typescript/ai-evaluation/src/types.ts
+++ b/typescript/ai-evaluation/src/types.ts
@@ -244,7 +244,9 @@ enum Comparator {
   /** Jaccard index (set-based similarity) */
   JACCARD = "JaccardSimilarity",
   /** Sørensen-Dice coefficient (set overlap) */
-  SORENSEN_DICE = "SorensenDiceSimilarity"
+  SORENSEN_DICE = "SorensenDiceSimilarity",
+  /** Soundex-based phonetic similarity (matches words that sound alike) */
+  PHONETIC = "PhoneticSimilarity"
 }
 
 /**


### PR DESCRIPTION


## What does this PR do?
feat: add PHONETIC comparator to Python and TypeScript SDK types

<!-- One paragraph. What problem does it solve, or what capability does it add? -->
PHONETIC = "PhoneticSimilarity" to the Comparator enum in both the Python and TypeScript SDKs, along with corresponding test assertions.

## Why?
PhoneticSimilarity was added to the main monorepo (future-agi/future-agi#<your PR number>) as a new grounded evaluator using pure Soundex encoding. This PR mirrors that addition in the SDK so customers can use Comparator.PHONETIC when calling AnswerSimilarity.
<!-- What was broken or missing? Link to any related issue: "Fixes #123" or "Closes #456" -->
Closes #47 

## How was it tested?

✅ Unit tests added/updated — added PHONETIC assertion to test_comparator_values in Python, updated count from 5 → 6 in both Python and TypeScript tests
✅TypeScript enum updated in types.ts with JSDoc comment
- [ ] Integration tests pass (or N/A — no gateway behavior changed)
- [ ] `ruff check` / `mypy` / `npm run typecheck` / `npm run lint` all pass
- [ ] Public types, env vars, or SDK behavior changes are documented in the relevant README

## Checklist

- ✅ Branch is off `dev`
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:` …)
- [ ] No TODOs or commented-out code left in
- ✅ No real API keys or secrets in the diff
- ✅Pure enum addition — no behavioral change to existing comparators
- [ ] If prose was added or changed: checked against [`docs/VOCABULARY.md`](../docs/VOCABULARY.md)

## Notes for reviewers

<!-- Anything that needs extra attention, or context that isn't obvious from the diff. -->
This is a companion PR to future-agi/future-agi#617 The PhoneticSimilarity implementation lives in the monorepo — this PR only exposes the enum value in the SDK so it's accessible to Python and TypeScript consumers.