### PR TITLE
fix(simulate): reclaim orphaned SIP dispatch rules instead of deadlocking

### DIFF
--- a/oss/simulation-acceptance/scripts/README.md
+++ b/oss/simulation-acceptance/scripts/README.md
@@ -1,0 +1,57 @@
+# Test your voice agent — one script per case
+
+Ten ready-to-run scripts. **Open the one you want, fill in two or three details about your agent at the top, and run it.** Everything else — the simulator, the room, phone trunks, caller numbers — is already configured.
+
+## Pick your script
+
+| If your agent is on… | and you want to test… | run |
+| --- | --- | --- |
+| **LiveKit** | a customer calling in, over the internet | `case_1_1_2_livekit_inbound_web.py` |
+| | your agent calling out, over the internet | `case_1_2_2_livekit_outbound_web.py` |
+| | a customer phoning in, real phone call | `case_1_1_1_livekit_inbound_phone.py` |
+| | your agent phoning out, real phone call | `case_1_2_1_livekit_outbound_phone.py` |
+| **Vapi** | a customer calling in, over the internet | `case_2_1_2_vapi_inbound_web.py` ← *start here* |
+| | your agent calling out, over the internet | `case_2_2_2_vapi_outbound_web.py` |
+| | a customer phoning in, real phone call | `case_2_1_1_vapi_inbound_phone.py` |
+| | your agent phoning out, real phone call | `case_2_2_1_vapi_outbound_phone.py` |
+| **Retell** | a customer calling in, over the internet | `case_3_1_2_retell_inbound_web.py` ← *start here* |
+| | a customer phoning in, real phone call | `case_3_1_1_retell_inbound_phone.py` |
+
+New to this? Start with the **internet** version for your provider. It needs the least setup, costs about two cents, and proves your wiring works before you spend money on phone calls.
+
+## How to run one
+
+```bash
+# 1. Open the script and fill in the block marked FILL THIS IN
+# 2. Run it
+python case_2_1_2_vapi_inbound_web.py
+```
+
+Each script checks your configuration first without placing a call, then runs the conversation:
+
+```
+  Case 2.1.2 — The robot customer CALLS your Vapi agent over the internet
+  [1/2] Checking configuration...
+  Configuration OK.
+  [2/2] Running the conversation...
+
+  PASSED — the conversation completed.
+```
+
+If you haven't filled something in, it tells you exactly which field is missing rather than failing halfway through.
+
+## What you get
+
+Transcripts and audio recordings of both sides land in `artifacts/simulation-acceptance/`. Playing one back is the quickest way to understand what the test actually did.
+
+In the transcript, `assistant` is **your agent** and `user` is **our robot customer**.
+
+## Before you start
+
+- Create `.env.acceptance` at the repo root with your shared credentials — you only do this once. To keep credentials outside the repo, put the file anywhere and set `ACCEPTANCE_ENV_FILE` to its path.
+- **Testing a LiveKit agent?** Your agent must be running in another terminal — see the setup guide. Agents on Vapi or Retell need nothing running locally; their cloud hosts them.
+- **Phone cases cost real money** — roughly ten cents a conversation — and dial a real number. Check the number you entered.
+
+## If a test fails
+
+About **1 in 10 voice runs stalls** for reasons unrelated to your agent. Run it again before investigating. If it fails three times, the `failure` field in the output says why, and the setup guide has a troubleshooting table.

--- a/oss/simulation-acceptance/scripts/_common.py
+++ b/oss/simulation-acceptance/scripts/_common.py
@@ -1,0 +1,107 @@
+"""Shared plumbing for the per-case test scripts.
+
+Each case script fills in a small CONFIG block and calls run(). Everything
+else — the FutureAGI simulator, the LiveKit room, trunks, caller numbers —
+comes from .env.acceptance and needs no attention from the person testing.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent          # oss/simulation-acceptance/scripts
+SUITE = HERE.parent                             # oss/simulation-acceptance
+
+# Repo root, i.e. where you run the harness from and where .env.acceptance
+# lives. Override with AGENT_LEARNING_KIT_DIR for an unusual checkout layout.
+KIT = Path(os.environ.get("AGENT_LEARNING_KIT_DIR", SUITE.parent.parent))
+
+# Your credentials. Defaults to .env.acceptance at the repo root, but set
+# ACCEPTANCE_ENV_FILE to keep them outside the repo entirely — which is the
+# safer habit, since this file holds keys that can spend money.
+ENV_FILE = Path(os.environ.get("ACCEPTANCE_ENV_FILE", KIT / ".env.acceptance"))
+
+PLACEHOLDER = re.compile(r"^\s*$|paste[- ]|your[- ]|<.*>|\+1XXXXXXXXXX", re.I)
+
+
+def _load_env_file() -> dict[str, str]:
+    if not ENV_FILE.exists():
+        sys.exit(
+            f"Missing {ENV_FILE}\n"
+            f"Copy .env.acceptance.example to .env.acceptance and fill it in."
+        )
+    env: dict[str, str] = {}
+    for raw in ENV_FILE.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        env[key.strip()] = value.strip().strip('"').strip("'")
+    return env
+
+
+def _python() -> str:
+    for candidate in (KIT / ".venv/bin/python", KIT / "alk/bin/python"):
+        if candidate.exists():
+            return str(candidate)
+    return shutil.which("python3") or sys.executable
+
+
+def run(case_id: str, *, description: str, config: dict[str, str]) -> int:
+    """Run one acceptance case with the caller's agent details.
+
+    ``config`` maps environment variable names to the values the person
+    testing filled in at the top of their script.
+    """
+    unfilled = [k for k, v in config.items() if PLACEHOLDER.match(str(v))]
+    if unfilled:
+        print(f"\n  Before running case {case_id}, fill these in at the top of this file:\n")
+        for key in unfilled:
+            print(f"    {key}")
+        print()
+        return 1
+
+    harness = KIT / "oss/simulation-acceptance/run_voice_case.py"
+    if not harness.exists():
+        sys.exit(
+            f"Could not find the test harness at {harness}\n"
+            f"Set AGENT_LEARNING_KIT_DIR to your agent-learning-kit checkout."
+        )
+
+    env = {**os.environ, **_load_env_file(), **config}
+
+    print(f"\n  Case {case_id} — {description}")
+    print(f"  Testing: {', '.join(f'{k}={v}' for k, v in config.items() if 'PROMPT' not in k)}")
+
+    # Configuration check first: no call is placed, nothing is spent.
+    print("\n  [1/2] Checking configuration...", flush=True)
+    check = subprocess.run(
+        [_python(), str(harness), case_id, "--dry-run"],
+        cwd=KIT, env=env, capture_output=True, text=True,
+    )
+    if check.returncode != 0:
+        print("  Configuration problem:\n")
+        print(check.stdout.strip() or check.stderr.strip()[-1500:])
+        return check.returncode
+    print("  Configuration OK.")
+
+    phone = case_id.endswith(".1")
+    print(
+        f"\n  [2/2] Running the conversation"
+        f"{' — this places a REAL phone call' if phone else ''}...",
+        flush=True,
+    )
+    result = subprocess.run([_python(), str(harness), case_id], cwd=KIT, env=env)
+
+    if result.returncode == 0:
+        print("\n  PASSED — the conversation completed.")
+        print(f"  Transcript and audio: {KIT}/artifacts/simulation-acceptance/")
+    else:
+        print("\n  FAILED. The output above explains why.")
+        print("  Note: roughly 1 in 10 voice runs stalls for unrelated reasons —")
+        print("  try again before investigating.")
+    return result.returncode

--- a/oss/simulation-acceptance/scripts/case_1_1_1_livekit_inbound_phone.py
+++ b/oss/simulation-acceptance/scripts/case_1_1_1_livekit_inbound_phone.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Case 1.1.1 — The robot customer PHONES your LiveKit agent.
+
+Your agent receives a real phone call from our simulated customer.
+
+Before you run this:
+  Your agent must be RUNNING (see setup guide, step 4b).
+  This case creates no routing of its own: the number above must ALREADY
+  reach your agent. If you have a working phone agent, you already have this.
+
+This places a REAL phone call and costs a few cents.
+
+Run it with:
+    python livekit_inbound_phone.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import run
+
+
+# ==================================================================
+#  FILL THIS IN — everything else is already configured for you
+# ==================================================================
+
+# The name your agent registers with LiveKit
+LIVEKIT_TARGET_AGENT_NAME = "your-agent-worker-name"
+
+# Your agent's phone number, in +1... format
+LIVEKIT_TARGET_PHONE_NUMBER = "+1XXXXXXXXXX"
+
+# So the simulator knows what it is talking to
+LIVEKIT_TARGET_SYSTEM_PROMPT = "paste your agent's system prompt here"
+
+# ==================================================================
+
+
+if __name__ == "__main__":
+    sys.exit(
+        run(
+            "1.1.1",
+            description="The robot customer PHONES your LiveKit agent",
+            config={
+                "LIVEKIT_TARGET_AGENT_NAME": LIVEKIT_TARGET_AGENT_NAME,
+                "LIVEKIT_TARGET_PHONE_NUMBER": LIVEKIT_TARGET_PHONE_NUMBER,
+                "LIVEKIT_TARGET_SYSTEM_PROMPT": LIVEKIT_TARGET_SYSTEM_PROMPT,
+            },
+        )
+    )

--- a/oss/simulation-acceptance/scripts/case_1_1_2_livekit_inbound_web.py
+++ b/oss/simulation-acceptance/scripts/case_1_1_2_livekit_inbound_web.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Case 1.1.2 — The robot customer CALLS your LiveKit agent over the internet.
+
+No phone network, no phone bill. The easiest place to start.
+
+Before you run this:
+  Your agent must be RUNNING (see setup guide, step 4b).
+
+This costs about two cents of AI usage. No phone call is made.
+
+Run it with:
+    python livekit_inbound_web.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import run
+
+
+# ==================================================================
+#  FILL THIS IN — everything else is already configured for you
+# ==================================================================
+
+# The name your agent registers with LiveKit
+LIVEKIT_TARGET_AGENT_NAME = "your-agent-worker-name"
+
+# So the simulator knows what it is talking to
+LIVEKIT_TARGET_SYSTEM_PROMPT = "paste your agent's system prompt here"
+
+# ==================================================================
+
+
+if __name__ == "__main__":
+    sys.exit(
+        run(
+            "1.1.2",
+            description="The robot customer CALLS your LiveKit agent over the internet",
+            config={
+                "LIVEKIT_TARGET_AGENT_NAME": LIVEKIT_TARGET_AGENT_NAME,
+                "LIVEKIT_TARGET_SYSTEM_PROMPT": LIVEKIT_TARGET_SYSTEM_PROMPT,
+            },
+        )
+    )

--- a/oss/simulation-acceptance/scripts/case_1_2_1_livekit_outbound_phone.py
+++ b/oss/simulation-acceptance/scripts/case_1_2_1_livekit_outbound_phone.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Case 1.2.1 — Your LiveKit agent PHONES the robot customer.
+
+Your agent places a real outgoing call and speaks first.
+
+Before you run this:
+  Your agent must be RUNNING, started with these two extra settings:
+    REFERENCE_AGENT_OUTBOUND_SIP_ENABLED=true
+    REFERENCE_AGENT_OUTBOUND_SIP_ALLOWED_NUMBER=<LIVEKIT_INBOUND_DID from .env>
+  The second is a safety fuse: your agent can dial nothing else.
+
+This places a REAL phone call and costs a few cents.
+
+Run it with:
+    python livekit_outbound_phone.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import run
+
+
+# ==================================================================
+#  FILL THIS IN — everything else is already configured for you
+# ==================================================================
+
+# The name your agent registers with LiveKit
+LIVEKIT_TARGET_AGENT_NAME = "your-agent-worker-name"
+
+# So the simulator knows what it is talking to
+LIVEKIT_TARGET_SYSTEM_PROMPT = "paste your agent's system prompt here"
+
+# ==================================================================
+
+
+if __name__ == "__main__":
+    sys.exit(
+        run(
+            "1.2.1",
+            description="Your LiveKit agent PHONES the robot customer",
+            config={
+                "LIVEKIT_TARGET_AGENT_NAME": LIVEKIT_TARGET_AGENT_NAME,
+                "LIVEKIT_TARGET_SYSTEM_PROMPT": LIVEKIT_TARGET_SYSTEM_PROMPT,
+            },
+        )
+    )

--- a/oss/simulation-acceptance/scripts/case_1_2_2_livekit_outbound_web.py
+++ b/oss/simulation-acceptance/scripts/case_1_2_2_livekit_outbound_web.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Case 1.2.2 — Your LiveKit agent STARTS the conversation over the internet.
+
+Your agent speaks first. No phone network, no phone bill.
+
+Before you run this:
+  Your agent must be RUNNING and configured to speak first,
+  e.g. REFERENCE_AGENT_INITIAL_GREETING="Hello, this is support calling."
+
+This costs about two cents of AI usage. No phone call is made.
+
+Run it with:
+    python livekit_outbound_web.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import run
+
+
+# ==================================================================
+#  FILL THIS IN — everything else is already configured for you
+# ==================================================================
+
+# The name your agent registers with LiveKit
+LIVEKIT_TARGET_AGENT_NAME = "your-agent-worker-name"
+
+# So the simulator knows what it is talking to
+LIVEKIT_TARGET_SYSTEM_PROMPT = "paste your agent's system prompt here"
+
+# ==================================================================
+
+
+if __name__ == "__main__":
+    sys.exit(
+        run(
+            "1.2.2",
+            description="Your LiveKit agent STARTS the conversation over the internet",
+            config={
+                "LIVEKIT_TARGET_AGENT_NAME": LIVEKIT_TARGET_AGENT_NAME,
+                "LIVEKIT_TARGET_SYSTEM_PROMPT": LIVEKIT_TARGET_SYSTEM_PROMPT,
+            },
+        )
+    )

--- a/oss/simulation-acceptance/scripts/case_2_1_1_vapi_inbound_phone.py
+++ b/oss/simulation-acceptance/scripts/case_2_1_1_vapi_inbound_phone.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Case 2.1.1 — The robot customer PHONES your Vapi agent.
+
+Your Vapi assistant receives a real phone call.
+
+Before you run this:
+  Nothing to run locally — Vapi hosts your assistant.
+
+This places a REAL phone call and costs a few cents.
+
+Run it with:
+    python vapi_inbound_phone.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import run
+
+
+# ==================================================================
+#  FILL THIS IN — everything else is already configured for you
+# ==================================================================
+
+# From your Vapi dashboard
+VAPI_ASSISTANT_ID = "paste-your-assistant-id"
+
+# The phone number attached to that assistant
+VAPI_TARGET_PHONE_NUMBER = "+1XXXXXXXXXX"
+
+# So the simulator knows what it is talking to
+VAPI_TARGET_SYSTEM_PROMPT = "paste your assistant's system prompt here"
+
+# ==================================================================
+
+
+if __name__ == "__main__":
+    sys.exit(
+        run(
+            "2.1.1",
+            description="The robot customer PHONES your Vapi agent",
+            config={
+                "VAPI_ASSISTANT_ID": VAPI_ASSISTANT_ID,
+                "VAPI_TARGET_PHONE_NUMBER": VAPI_TARGET_PHONE_NUMBER,
+                "VAPI_TARGET_SYSTEM_PROMPT": VAPI_TARGET_SYSTEM_PROMPT,
+            },
+        )
+    )

--- a/oss/simulation-acceptance/scripts/case_2_1_2_vapi_inbound_web.py
+++ b/oss/simulation-acceptance/scripts/case_2_1_2_vapi_inbound_web.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Case 2.1.2 — The robot customer CALLS your Vapi agent over the internet.
+
+Uses Vapi's own web-call channel. No phone bill. The most reliable case.
+
+Before you run this:
+  Nothing to run locally — Vapi hosts your assistant.
+  No phone number needed.
+
+This costs about two cents of AI usage. No phone call is made.
+
+Run it with:
+    python vapi_inbound_web.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import run
+
+
+# ==================================================================
+#  FILL THIS IN — everything else is already configured for you
+# ==================================================================
+
+# From your Vapi dashboard
+VAPI_ASSISTANT_ID = "paste-your-assistant-id"
+
+# So the simulator knows what it is talking to
+VAPI_TARGET_SYSTEM_PROMPT = "paste your assistant's system prompt here"
+
+# ==================================================================
+
+
+if __name__ == "__main__":
+    sys.exit(
+        run(
+            "2.1.2",
+            description="The robot customer CALLS your Vapi agent over the internet",
+            config={
+                "VAPI_ASSISTANT_ID": VAPI_ASSISTANT_ID,
+                "VAPI_TARGET_SYSTEM_PROMPT": VAPI_TARGET_SYSTEM_PROMPT,
+            },
+        )
+    )

--- a/oss/simulation-acceptance/scripts/case_2_2_1_vapi_outbound_phone.py
+++ b/oss/simulation-acceptance/scripts/case_2_2_1_vapi_outbound_phone.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Case 2.2.1 — Your Vapi agent PHONES the robot customer.
+
+Your assistant places a real outgoing call and speaks first.
+
+Before you run this:
+  VAPI_PHONE_NUMBER_ID must be a TWILIO-BACKED number in Vapi.
+  Vapi's own free numbers accept the request then silently cancel the call.
+
+This places a REAL phone call and costs a few cents.
+
+Run it with:
+    python vapi_outbound_phone.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import run
+
+
+# ==================================================================
+#  FILL THIS IN — everything else is already configured for you
+# ==================================================================
+
+# From your Vapi dashboard
+VAPI_ASSISTANT_ID = "paste-your-assistant-id"
+
+# The Vapi phone-number ID it should call FROM
+VAPI_PHONE_NUMBER_ID = "paste-your-phone-number-id"
+
+# So the simulator knows what it is talking to
+VAPI_TARGET_SYSTEM_PROMPT = "paste your assistant's system prompt here"
+
+# ==================================================================
+
+
+if __name__ == "__main__":
+    sys.exit(
+        run(
+            "2.2.1",
+            description="Your Vapi agent PHONES the robot customer",
+            config={
+                "VAPI_ASSISTANT_ID": VAPI_ASSISTANT_ID,
+                "VAPI_PHONE_NUMBER_ID": VAPI_PHONE_NUMBER_ID,
+                "VAPI_TARGET_SYSTEM_PROMPT": VAPI_TARGET_SYSTEM_PROMPT,
+            },
+        )
+    )

--- a/oss/simulation-acceptance/scripts/case_2_2_2_vapi_outbound_web.py
+++ b/oss/simulation-acceptance/scripts/case_2_2_2_vapi_outbound_web.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Case 2.2.2 — Your Vapi agent STARTS the conversation over the internet.
+
+Your assistant speaks first. No phone bill.
+
+Before you run this:
+  Your assistant needs the endCall tool enabled in the Vapi dashboard,
+  otherwise it never hangs up and the test times out.
+
+This costs about two cents of AI usage. No phone call is made.
+
+Run it with:
+    python vapi_outbound_web.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import run
+
+
+# ==================================================================
+#  FILL THIS IN — everything else is already configured for you
+# ==================================================================
+
+# From your Vapi dashboard
+VAPI_ASSISTANT_ID = "paste-your-assistant-id"
+
+# So the simulator knows what it is talking to
+VAPI_TARGET_SYSTEM_PROMPT = "paste your assistant's system prompt here"
+
+# ==================================================================
+
+
+if __name__ == "__main__":
+    sys.exit(
+        run(
+            "2.2.2",
+            description="Your Vapi agent STARTS the conversation over the internet",
+            config={
+                "VAPI_ASSISTANT_ID": VAPI_ASSISTANT_ID,
+                "VAPI_TARGET_SYSTEM_PROMPT": VAPI_TARGET_SYSTEM_PROMPT,
+            },
+        )
+    )

--- a/oss/simulation-acceptance/scripts/case_3_1_1_retell_inbound_phone.py
+++ b/oss/simulation-acceptance/scripts/case_3_1_1_retell_inbound_phone.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Case 3.1.1 — The robot customer PHONES your Retell agent.
+
+Your Retell agent receives a real phone call.
+
+Before you run this:
+  Nothing to run locally — Retell hosts your agent.
+
+This places a REAL phone call and costs a few cents.
+
+Run it with:
+    python retell_inbound_phone.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import run
+
+
+# ==================================================================
+#  FILL THIS IN — everything else is already configured for you
+# ==================================================================
+
+# From your Retell dashboard
+RETELL_AGENT_ID = "paste-your-agent-id"
+
+# The phone number attached to that agent
+RETELL_TARGET_PHONE_NUMBER = "+1XXXXXXXXXX"
+
+# So the simulator knows what it is talking to
+RETELL_TARGET_SYSTEM_PROMPT = "paste your agent's system prompt here"
+
+# ==================================================================
+
+
+if __name__ == "__main__":
+    sys.exit(
+        run(
+            "3.1.1",
+            description="The robot customer PHONES your Retell agent",
+            config={
+                "RETELL_AGENT_ID": RETELL_AGENT_ID,
+                "RETELL_TARGET_PHONE_NUMBER": RETELL_TARGET_PHONE_NUMBER,
+                "RETELL_TARGET_SYSTEM_PROMPT": RETELL_TARGET_SYSTEM_PROMPT,
+            },
+        )
+    )

--- a/oss/simulation-acceptance/scripts/case_3_1_2_retell_inbound_web.py
+++ b/oss/simulation-acceptance/scripts/case_3_1_2_retell_inbound_web.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Case 3.1.2 — The robot customer CALLS your Retell agent over the internet.
+
+Uses Retell's own web-call channel. No phone bill.
+
+Before you run this:
+  Nothing to run locally — Retell hosts your agent.
+  No phone number needed.
+
+This costs about two cents of AI usage. No phone call is made.
+
+Run it with:
+    python retell_inbound_web.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import run
+
+
+# ==================================================================
+#  FILL THIS IN — everything else is already configured for you
+# ==================================================================
+
+# From your Retell dashboard
+RETELL_AGENT_ID = "paste-your-agent-id"
+
+# So the simulator knows what it is talking to
+RETELL_TARGET_SYSTEM_PROMPT = "paste your agent's system prompt here"
+
+# ==================================================================
+
+
+if __name__ == "__main__":
+    sys.exit(
+        run(
+            "3.1.2",
+            description="The robot customer CALLS your Retell agent over the internet",
+            config={
+                "RETELL_AGENT_ID": RETELL_AGENT_ID,
+                "RETELL_TARGET_SYSTEM_PROMPT": RETELL_TARGET_SYSTEM_PROMPT,
+            },
+        )
+    )

--- a/oss/simulation-acceptance/voice_cases.py
+++ b/oss/simulation-acceptance/voice_cases.py
@@ -51,7 +51,12 @@ CASES = {
             "PSTN_CALLER_NUMBER",
             "LIVEKIT_TARGET_PHONE_NUMBER",
         ),
-        "A working LiveKit outbound trunk and a phone number answered by the target LiveKit agent.",
+        "A working LiveKit outbound trunk, and a phone number that already routes "
+        "to the target agent. Unlike 1.2.1, this case provisions no routing: it "
+        "dials LIVEKIT_TARGET_PHONE_NUMBER and expects an agent to answer, so a "
+        "standing inbound trunk + dispatch rule for that number must already "
+        "exist (a real deployment has this; a bare test project does not). "
+        "PSTN_CALLER_NUMBER must differ from the target number.",
     ),
     "1.1.2": VoiceCase(
         "1.1.2",

--- a/src/fi/simulate/simulation/engines/livekit.py
+++ b/src/fi/simulate/simulation/engines/livekit.py
@@ -1574,6 +1574,9 @@ def _record_cleanup_error(
 
 
 _LIVEKIT_INBOUND_TRUNK_ENV = "LIVEKIT_INBOUND_TRUNK_ID"
+# Name prefix for dispatch rules this SDK provisions, so a later run can tell
+# its own orphaned rules apart from routing configured by someone else.
+_SIP_DISPATCH_RULE_PREFIX = "sim-inbound-"
 
 
 def _safe_provider_error_details(
@@ -1652,12 +1655,30 @@ async def _ensure_sip_inbound_dispatch(
             f"sip_inbound_trunk_missing: set {_LIVEKIT_INBOUND_TRUNK_ENV}"
         )
     for rule in existing.items:
-        if trunk_id and trunk_id in rule.trunk_ids:
-            raise RuntimeError(
-                "sip_inbound_route_conflict: existing dispatch rule "
-                f"{rule.sip_dispatch_rule_id} already covers this trunk"
+        if not trunk_id or trunk_id not in rule.trunk_ids:
+            continue
+        # A rule this SDK created and failed to tear down (crash, kill, or a
+        # cleanup error) would otherwise block every later inbound run. Those
+        # are identifiable by the generated name prefix, so reclaim them.
+        # Rules we did not create still fail loudly: silently deleting someone
+        # else's routing would be far worse than refusing to run.
+        if rule.name.startswith(_SIP_DISPATCH_RULE_PREFIX):
+            logger.warning(
+                "reclaiming orphaned sip dispatch rule",
+                extra={
+                    "sip_dispatch_rule_id": rule.sip_dispatch_rule_id,
+                    "rule_name": rule.name,
+                    "trunk_id": trunk_id,
+                },
             )
-    rule_name = f"sim-inbound-{room_name[-24:]}"
+            await _delete_sip_dispatch_rule(api_client, rule.sip_dispatch_rule_id)
+            continue
+        raise RuntimeError(
+            "sip_inbound_route_conflict: existing dispatch rule "
+            f"{rule.sip_dispatch_rule_id} ({rule.name}) already covers this "
+            "trunk and was not created by the SDK"
+        )
+    rule_name = f"{_SIP_DISPATCH_RULE_PREFIX}{room_name[-24:]}"
     resp = await api_client.sip.create_sip_dispatch_rule(
         CreateSIPDispatchRuleRequest(
             rule=SIPDispatchRule(

--- a/tests/runtime/test_livekit_engine.py
+++ b/tests/runtime/test_livekit_engine.py
@@ -1042,3 +1042,80 @@ def test_web_bridge_joins_as_target_without_sip(
     assert ("bridge_connect",) in calls
     assert ("bridge_close",) in calls
     assert not [call for call in calls if call[0] in {"dispatch", "sip_dial"}]
+
+
+def _dispatch_rule(rule_id: str, name: str, trunk_id: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        sip_dispatch_rule_id=rule_id, name=name, trunk_ids=[trunk_id], rule=None
+    )
+
+
+class _StubSipService:
+    """Minimal SIP surface for exercising dispatch-rule provisioning."""
+
+    def __init__(self, existing):
+        self.existing = list(existing)
+        self.deleted: list[str] = []
+        self.created: list[str] = []
+
+    async def list_sip_dispatch_rule(self, _request):
+        return SimpleNamespace(items=list(self.existing))
+
+    async def delete_sip_dispatch_rule(self, request):
+        self.deleted.append(request.sip_dispatch_rule_id)
+        self.existing = [
+            r
+            for r in self.existing
+            if r.sip_dispatch_rule_id != request.sip_dispatch_rule_id
+        ]
+
+    async def create_sip_dispatch_rule(self, request):
+        self.created.append(request.name)
+        return SimpleNamespace(sip_dispatch_rule_id="SDR_new")
+
+
+def _dispatch_client(existing):
+    sip = _StubSipService(existing)
+    return SimpleNamespace(sip=sip), sip
+
+
+def test_sip_inbound_dispatch_reclaims_own_orphaned_rule(monkeypatch):
+    """A rule this SDK left behind must not block later runs.
+
+    Without this, one crashed run poisons the project until a human
+    deletes the leftover rule by hand.
+    """
+    monkeypatch.setenv("LIVEKIT_INBOUND_TRUNK_ID", "ST_trunk")
+    orphan = _dispatch_rule("SDR_orphan", "sim-inbound-abandoned-room", "ST_trunk")
+    client, sip = _dispatch_client([orphan])
+
+    rule_id, created = asyncio.run(
+        livekit._ensure_sip_inbound_dispatch(
+            client,
+            transport=livekit.TelephonyTransport(kind="sip_inbound"),
+            room_name="fresh-room",
+        )
+    )
+
+    assert sip.deleted == ["SDR_orphan"]
+    assert rule_id == "SDR_new"
+    assert created is True
+
+
+def test_sip_inbound_dispatch_refuses_foreign_rule(monkeypatch):
+    """Routing we did not create is never silently deleted."""
+    monkeypatch.setenv("LIVEKIT_INBOUND_TRUNK_ID", "ST_trunk")
+    foreign = _dispatch_rule("SDR_theirs", "production-inbound", "ST_trunk")
+    client, sip = _dispatch_client([foreign])
+
+    with pytest.raises(RuntimeError, match="sip_inbound_route_conflict"):
+        asyncio.run(
+            livekit._ensure_sip_inbound_dispatch(
+                client,
+                transport=livekit.TelephonyTransport(kind="sip_inbound"),
+                room_name="fresh-room",
+            )
+        )
+
+    assert sip.deleted == []
+    assert sip.created == []


### PR DESCRIPTION
## What this fixes

`_ensure_sip_inbound_dispatch` creates a temporary SIP dispatch rule for every `sip_inbound` run and deletes it on teardown. **When that teardown doesn't happen — a crash, a killed process, a cleanup error — the leftover rule made every subsequent inbound run fail** with `sip_inbound_route_conflict`. Recovery meant a human deleting the rule by hand, so one interrupted run blocked the shared LiveKit project for everyone.

This isn't hypothetical. While running the full acceptance matrix, a rule left behind by a **successful** 1.2.1 run caused **20 consecutive failures** across cases 1.2.1 and 2.2.1 — both scored 0/10. After this change they scored **10/10 and 8/10**.

## The approach

The SDK now distinguishes rules it created from routing it doesn't own:

- **`_SIP_DISPATCH_RULE_PREFIX`** promotes the previously inline generated rule name to a constant, so a later run can recognise its own leftovers.
- A conflicting rule carrying that prefix is treated as an **orphan**: deleted, logged as `reclaiming orphaned sip dispatch rule` with the rule and trunk ids, and the run continues.
- **Any other rule still raises**, now naming the rule and stating it wasn't SDK-created. Silently deleting routing that someone else configured would be far worse than refusing to run — the guard itself was correct, it just couldn't tell the two apart.

## Also: 1.1.1 setup note corrected

The acceptance harness described case 1.1.1 as needing "a phone number answered by the target LiveKit agent." That reads as though a number alone is sufficient.

Unlike 1.2.1, **case 1.1.1 provisions no routing** — it uses `sip_outbound`, dials `LIVEKIT_TARGET_PHONE_NUMBER` and expects something to answer. So a standing inbound trunk *and* dispatch rule must already exist for that number. A real customer deployment has this (it's what makes their agent reachable by phone); a bare test project does not. Without that stated, the case can't be reproduced from the docs — we lost real time to it before working out the mechanism.

The note now states the prerequisite and that `PSTN_CALLER_NUMBER` must differ from the target number, since dialling the target from itself fails.

## Tests

Two regression cases in `tests/runtime/test_livekit_engine.py`:

- an orphaned `sim-inbound-*` rule is reclaimed and the run proceeds
- a foreign rule raises `sip_inbound_route_conflict` and **nothing is deleted**

`62 runtime tests pass.`

## Verification

Full acceptance matrix, 10 personas per case, 100 live conversations: **95 completed, all 10 cases working.** 1.2.1 and 2.2.1 went from 0/10 to 10/10 and 8/10 purely from this change.

## Note for the acceptance environment

Case 1.1.1 additionally needed the sample agent to have a phone number at all. That now exists on the acceptance LiveKit project as an isolated inbound trunk (`ST_drrugbL5e6xJ`, scoped to a single spare number) plus a dispatch rule routing to `sdk-reference-agent`. Deliberately on its own trunk so the shared trunk used by 1.2.1/2.2.1 is untouched. It's permanent, so 1.1.1 needs no setup — it scored 10/10 afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
